### PR TITLE
Bugfix: Crash on empty image #27

### DIFF
--- a/Core/PietInterpreter/Src/PietImageTokeniser.cpp
+++ b/Core/PietInterpreter/Src/PietImageTokeniser.cpp
@@ -11,6 +11,11 @@ const char* PietImageTokeniser::i_directionIcons[static_cast<int>(Direction::Cou
 
 PietToken PietImageTokeniser::Pop_Internal()
 {
+    if (m_imageData == nullptr) 
+    {
+        return PietToken::TokenType::End;
+    }
+
 	m_currentBlock = GetBlockInfo(m_currentBlock.m_endingCodel, m_currentBlock.m_endingDirectionPointer, m_currentBlock.m_endingCodelChooser);
 
 	if (m_currentBlock.m_startingCodel == m_currentBlock.m_endingCodel)


### PR DESCRIPTION
Hello, @yanniknelson!
This is Surya!

This PR addresses,
1. Crash on empty image.

I've added a nullptr check in `Pop_Internal()`, now if `m_imageData` is nullptr, it returns `PietToken::TokenType::End`.