### PR TITLE
HOTFIX: Build Script

### DIFF
--- a/Build.lua
+++ b/Build.lua
@@ -23,17 +23,17 @@ project "Premake"
 
         filter "system:windows"
             postbuildcommands {
-                "%{wks.location}/Vendor/Binaries/Premake/Windows/premake5.exe %{_ACTION} --file=\"%{wks.location}Build.lua\""
+                "%{wks.location}/Vendor/Binaries/Premake/Windows/premake5.exe %{_ACTION} --file=\"%{wks.location}/Build.lua\""
             }
 
         filter "system:linux"
             postbuildcommands {
-                "%{wks.location}/Vendor/Binaries/Premake/Linux/premake5 %{_ACTION} --file=\"%{wks.location}Build.lua\""
+                "%{wks.location}/Vendor/Binaries/Premake/Linux/premake5 %{_ACTION} --file=\"%{wks.location}/Build.lua\""
             }
 
         filter "system:macosx"
             postbuildcommands {
-                "%{wks.location}/Vendor/Binaries/Premake/macOS/premake5 %{_ACTION} --file=\"%{wks.location}Build.lua\""
+                "%{wks.location}/Vendor/Binaries/Premake/macOS/premake5 %{_ACTION} --file=\"%{wks.location}/Build.lua\""
             }
 
         filter {} -- Clear filter


### PR DESCRIPTION
This is very crucial error that I found in Build.lua,

The previous and the version that I gave in the previous PR both had,

```bash
--file=\"%{wks.location}Build.lua\""
```

When the directory is current directory (.) it becomes,

```bash
--file=".Build.lua"
```

This is a error. So I added path seperator,

```bash
--file=\"%{wks.location}/Build.lua\""
```

So, now it becomes,

```bash
--file="./Build.lua"
```